### PR TITLE
Yarn Command Correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ View the full [Storybook documentation](https://react-carousel.codely.com/).
    ```
    or
    ```sh
-   yarn @codelytv/react-carousel
+   yarn add @codelytv/react-carousel
    ```
 2. Import and use:
    ```javascript


### PR DESCRIPTION
Change summary:

- Added the term add to the yarn command within the README.md to ensure users utilize the command correctly.

Reason for Change:

- It was identified that the previous instruction in the README could lead to confusion as it omitted the add term. This correction will make it easier for new contributors or project users to install dependencies correctly.